### PR TITLE
interfaceの情報を取得する

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![feature(iterator_fold_self)]
 
 pub mod cpu;
+pub mod disk;
 pub mod loadavg;
 pub mod memory;
-pub mod disk;
+pub mod network;

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,0 +1,66 @@
+use std::io::{BufRead, BufReader, Read};
+
+#[derive(Default, Debug, PartialEq)]
+pub struct Network {
+    pub name: String,
+    pub rx_bytes: u64,
+    pub tx_bytes: u64,
+}
+
+pub fn get() -> std::io::Result<Vec<Network>> {
+    let file = std::fs::File::open("/proc/net/dev")?;
+    collect_network_stats(file)
+}
+
+fn collect_network_stats<R: Read>(file: R) -> std::io::Result<Vec<Network>> {
+    let reader = BufReader::new(file);
+    let networks = reader
+        .lines()
+        .skip(2)
+        .map(|line| {
+            let line = line.unwrap();
+            let columns: Vec<&str> = line.split(":").collect();
+            let name = columns[0].trim_start();
+            dbg!(name);
+            let columns: Vec<&str> = columns[1].split_ascii_whitespace().collect();
+            Network {
+                name: name.to_owned(),
+                rx_bytes: columns[0].parse::<u64>().unwrap(),
+                tx_bytes: columns[8].parse::<u64>().unwrap(),
+            }
+        })
+        .filter(|network| network.name != "lo")
+        .collect();
+    Ok(networks)
+}
+
+#[test]
+fn test_collect_network_stats() {
+    let buf = "Inter-|   Receive                                                |  Transmit
+ face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
+ wlan0: 1188035151  850857    0    0    0     0          0         0 49774221  428282    0    0    0     0       0          0
+    lo: 1292817    9913    0    0    0     0          0         0  1292817    9913    0    0    0     0       0          0
+  eth0: 26054426   73542    0    0    0     0          0         0 12352148   58473    0    0    0     0       0          0
+  eth1:183651236    3482    0    0    0     0          0         0 93127469    1924    0    0    0     0       0          0".as_bytes();
+    let expected = vec![
+        Network {
+            name: "wlan0".to_owned(),
+            rx_bytes: 1188035151,
+            tx_bytes: 49774221,
+        },
+        Network {
+            name: "eth0".to_owned(),
+            rx_bytes: 26054426,
+            tx_bytes: 12352148,
+        },
+        Network {
+            name: "eth1".to_owned(),
+            rx_bytes: 183651236,
+            tx_bytes: 93127469,
+        },
+    ];
+    let r = collect_network_stats(buf);
+    assert!(r.is_ok());
+    let stats = r.unwrap();
+    assert_eq!(stats, expected);
+}

--- a/src/network.rs
+++ b/src/network.rs
@@ -19,10 +19,15 @@ fn collect_network_stats<R: Read>(file: R) -> std::io::Result<Vec<Network>> {
         .skip(2)
         .map(|line| {
             let line = line.unwrap();
-            let columns: Vec<&str> = line.split(":").collect();
+            let columns: Vec<_> = line.split(":").collect();
+            if columns.len() < 2 {
+                unimplemented!();
+            }
             let name = columns[0].trim_start();
-            dbg!(name);
-            let columns: Vec<&str> = columns[1].split_ascii_whitespace().collect();
+            let columns: Vec<_> = columns[1].split_ascii_whitespace().collect();
+            if columns.len() < 9 {
+                unimplemented!();
+            }
             Network {
                 name: name.to_owned(),
                 rx_bytes: columns[0].parse::<u64>().unwrap(),


### PR DESCRIPTION
interfaceの情報を取得する

```go
type Stats struct {
	Name             string
	RxBytes, TxBytes uint64
}
```

sysfs (←今存在を知った) の `/sys/class/net/eth0/statistics/rx_bytes`, `/sys/class/net/eth0/statistics/tx_bytes`でも読めさう。取敢ずはprocfsで。