### PR TITLE
filesystemの情報を取得する

### DIFF
--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -26,6 +26,7 @@ fn collect_filesystem_stats<R: Read>(buf: R) -> std::io::Result<Vec<FileSystem>>
             line.starts_with("/dev/")
                 && !line.starts_with("/dev/mapper/docker-")
                 && !line.starts_with("/dev/dm-")
+                && !line.contains("devicemapper/mnt")
         })
         .map(|line| {
             let columns: Vec<_> = line.split_ascii_whitespace().collect();

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -1,0 +1,62 @@
+use std::process::Command;
+
+#[derive(Default, Debug, PartialEq)]
+pub struct FileSystem {
+    pub name: String,
+    pub used: u64,
+    pub size: u64,
+}
+
+pub fn get() -> std::io::Result<Vec<FileSystem>> {
+    let output = Command::new("df")
+        .arg("-Pkl")
+        .output()
+        .expect("failed to run");
+    collect_filesystem_stats(String::from_utf8(output.stdout).unwrap())
+}
+
+fn collect_filesystem_stats(output: String) -> std::io::Result<Vec<FileSystem>> {
+    let file_systems = output
+        .lines()
+        .skip(1)
+        .filter(|line| {
+            line.starts_with("/dev/")
+                && !line.starts_with("/dev/mapper/docker-")
+                && !line.starts_with("/dev/dm-")
+        })
+        .map(|line| {
+            let columns: Vec<_> = line.split_ascii_whitespace().collect();
+            if columns.len() < 4 {
+                unimplemented!()
+            }
+            let used_kb = columns[2].parse::<u64>().unwrap();
+            let available_kb = columns[3].parse::<u64>().unwrap();
+            FileSystem {
+                name: columns[0].trim_start_matches("/dev/").to_owned(),
+                used: used_kb * 1024,
+                size: (used_kb + available_kb) * 1024,
+            }
+        })
+        .collect();
+    Ok(file_systems)
+}
+
+#[test]
+fn test_collect_filesystem_stats() {
+    let output = "Filesystem                         1024-blocks     Used Available Capacity Mounted on
+/dev/sda1                             19734388 16868164 1863772        91% /
+tmpfs                                   517224        0  517224         0% /lib/init/rw
+udev                                    512780       96  512684         1% /dev
+tmpfs                                   517224        4  517220         1% /dev/shm
+/dev/mapper/docker-000:0-000-00000    10190136   168708 9480756         2% /var/lib/docker/devicemapper/mnt/00000
+/dev/dm-4                             10474496   149684 10324812        2% /var/lib/docker/devicemapper/mnt/11111".to_owned();
+    let expected = vec![FileSystem {
+        name: "sda1".to_owned(),
+        used: 17272999936,
+        size: 19181502464,
+    }];
+    let r = collect_filesystem_stats(output);
+    assert!(r.is_ok());
+    let stats = r.unwrap();
+    assert_eq!(stats, expected);
+}

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -1,3 +1,4 @@
+use std::io::{BufRead, BufReader, Read};
 use std::process::Command;
 
 #[derive(Default, Debug, PartialEq)]
@@ -12,13 +13,15 @@ pub fn get() -> std::io::Result<Vec<FileSystem>> {
         .arg("-Pkl")
         .output()
         .expect("failed to run");
-    collect_filesystem_stats(String::from_utf8(output.stdout).unwrap())
+    collect_filesystem_stats(std::io::Cursor::new(output.stdout))
 }
 
-fn collect_filesystem_stats(output: String) -> std::io::Result<Vec<FileSystem>> {
-    let file_systems = output
+fn collect_filesystem_stats<R: Read>(buf: R) -> std::io::Result<Vec<FileSystem>> {
+    let reader = BufReader::new(buf);
+    let file_systems = reader
         .lines()
         .skip(1)
+        .map(|line| line.unwrap())
         .filter(|line| {
             line.starts_with("/dev/")
                 && !line.starts_with("/dev/mapper/docker-")
@@ -49,7 +52,7 @@ tmpfs                                   517224        0  517224         0% /lib/
 udev                                    512780       96  512684         1% /dev
 tmpfs                                   517224        4  517220         1% /dev/shm
 /dev/mapper/docker-000:0-000-00000    10190136   168708 9480756         2% /var/lib/docker/devicemapper/mnt/00000
-/dev/dm-4                             10474496   149684 10324812        2% /var/lib/docker/devicemapper/mnt/11111".to_owned();
+/dev/dm-4                             10474496   149684 10324812        2% /var/lib/docker/devicemapper/mnt/11111".as_bytes();
     let expected = vec![FileSystem {
         name: "sda1".to_owned(),
         used: 17272999936,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod cpu;
 pub mod disk;
+pub mod filesystem;
 pub mod loadavg;
 pub mod memory;
 pub mod network;


### PR DESCRIPTION
filesystemの情報を取得する

mackerel-agent

```go
type DfStat struct {
	Name      string
	Blocks    uint64
	Used      uint64
	Available uint64
	Capacity  uint8
	Mounted   string
}
```

```go
			ret["filesystem."+metricName+".size"] = float64(dfs.Used+dfs.Available) * 1024
			ret["filesystem."+metricName+".used"] = float64(dfs.Used) * 1024
```

gopsutil

```go
type UsageStat struct {
	Path              string  `json:"path"`
	Fstype            string  `json:"fstype"`
	Total             uint64  `json:"total"`
	Free              uint64  `json:"free"`
	Used              uint64  `json:"used"`
	UsedPercent       float64 `json:"usedPercent"`
	InodesTotal       uint64  `json:"inodesTotal"`
	InodesUsed        uint64  `json:"inodesUsed"`
	InodesFree        uint64  `json:"inodesFree"`
	InodesUsedPercent float64 `json:"inodesUsedPercent"`
}
```

アーキテクチャ毎にsyscallでとるの大変だからおとなしく`df`を叩かう。
参考は https://github.com/mackerelio/mackerel-agent/blob/da65694c9574104c564721286241ca662fd4882c/metrics/filesystem.go とそこから呼ばれる https://github.com/mackerelio/mackerel-agent/blob/da65694c9574104c564721286241ca662fd4882c/util/filesystem.go#L62